### PR TITLE
Add RFXGEN_GEN_SAMPLE_SIZE and RFXGEN_GEN_CHANNELS

### DIFF
--- a/src/rfxgen.c
+++ b/src/rfxgen.c
@@ -323,9 +323,9 @@ int main(int argc, char *argv[])
         ResetWaveParams(&params[i]);
 
         // Default wave values
-        wave[i].sampleRate = 44100;
-        wave[i].sampleSize = 32;        // 32 bit -> float
-        wave[i].channels = 1;           // 1 channel -> mono
+        wave[i].sampleRate = RFXGEN_GEN_SAMPLE_RATE;
+        wave[i].sampleSize = RFXGEN_GEN_SAMPLE_SIZE;
+        wave[i].channels = RFXGEN_GEN_CHANNELS;
         wave[i].frameCount = 10*wave[i].sampleRate;    // Max frame count for 10 seconds
         wave[i].data = (float *)RL_CALLOC(wave[i].frameCount, sizeof(float));
 
@@ -1090,8 +1090,8 @@ static void ProcessCommandLine(int argc, char *argv[])
 
             // NOTE: GenerateWave() returns data as 32bit float, 1 channel by default
             wave.sampleRate = RFXGEN_GEN_SAMPLE_RATE;
-            wave.sampleSize = 32;
-            wave.channels = 1;
+            wave.sampleSize = RFXGEN_GEN_SAMPLE_SIZE;
+            wave.channels = RFXGEN_GEN_CHANNELS;
             wave.data = GenerateWave(params, &wave.frameCount);
         }
         else if (IsFileExtension(inFileName, ".wav") ||

--- a/src/rfxgen.h
+++ b/src/rfxgen.h
@@ -73,11 +73,8 @@ extern "C" {            // Prevents name mangling of functions
     #define RFXGEN_GEN_SAMPLE_RATE 44100    // Default sample rate
 #endif
 
-#if !defined(RFXGEN_GEN_SAMPLE_SIZE)
-    #define RFXGEN_GEN_SAMPLE_SIZE 32       // Generated waves are 32 bit -> float
-#endif
-#if !defined(RFXGEN_GEN_CHANNELS)
-    #define RFXGEN_GEN_CHANNELS 1           // Generated waves are 1 channel
+#define RFXGEN_GEN_SAMPLE_SIZE 32           // The sample size of generated waves (32 bit -> float)
+#define RFXGEN_GEN_CHANNELS 1               // The number of channels that are generated for waves (only 1)
 #endif
 
 //----------------------------------------------------------------------------------

--- a/src/rfxgen.h
+++ b/src/rfxgen.h
@@ -70,7 +70,14 @@ extern "C" {            // Prevents name mangling of functions
 // Defines and Macros
 //----------------------------------------------------------------------------------
 #if !defined(RFXGEN_GEN_SAMPLE_RATE)
-    #define RFXGEN_GEN_SAMPLE_RATE      44100     // Default sample rate
+    #define RFXGEN_GEN_SAMPLE_RATE 44100    // Default sample rate
+#endif
+
+#if !defined(RFXGEN_GEN_SAMPLE_SIZE)
+    #define RFXGEN_GEN_SAMPLE_SIZE 32       // Generated waves are 32 bit -> float
+#endif
+#if !defined(RFXGEN_GEN_CHANNELS)
+    #define RFXGEN_GEN_CHANNELS 1           // Generated waves are 1 channel
 #endif
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Make the code a bit more readable by having `RFXGEN_GEN_SAMPLE_SIZE` and `RFXGEN_GEN_CHANNELS` constants. Magic numbers are ambiguous and can cause confusion.