### PR TITLE
Review of CMake build scripts

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -30,11 +30,4 @@ if(${BUILD_RFXGEN})
     if (${PLATFORM} STREQUAL "Web")
         set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
     endif()
-
-    # MacOS
-    if (APPLE)
-        target_link_libraries(${PROJECT_NAME} "-framework IOKit")
-        target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
-        target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
-    endif()
 endif()

--- a/projects/CMake/cmake/FindRaylib.cmake
+++ b/projects/CMake/cmake/FindRaylib.cmake
@@ -4,7 +4,7 @@ if (NOT raylib_FOUND)
     FetchContent_Declare(
         raylib
         GIT_REPOSITORY https://github.com/raysan5/raylib.git
-        GIT_TAG 4.2.0
+        GIT_TAG cb085a1b50324315ec77f134be3447107c52cf2d
     )
     FetchContent_GetProperties(raylib)
     if (NOT raylib_POPULATED) # Have we downloaded raylib yet?


### PR DESCRIPTION
Removed unneeded macOS target_link_library calls and pinned raylib to newer version compatible to the current raygui.h, I didn't use master but a commit id, to not let the build break when ray lib changes but rfxgen doesn't.