### PR TITLE
Disable 1, 2, 3, 4, 5, P and Space shortcuts when saving

### DIFF
--- a/src/rfxgen.c
+++ b/src/rfxgen.c
@@ -446,8 +446,6 @@ int main(int argc, char *argv[])
 
         // Keyboard shortcuts
         //------------------------------------------------------------------------------------
-        if (IsKeyPressed(KEY_SPACE)) PlaySound(sound[mainToolbarState.soundSlotActive]);  // Play current sound
-
         // Show dialog: save sound (.rfx)
         if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_S))
         {
@@ -461,12 +459,20 @@ int main(int argc, char *argv[])
         // Show dialog: export wave (.wav, .qoa, .raw, .h)
         if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_E)) windowExportActive = true;
 
-        // Select current sound slot
-        if (IsKeyPressed(KEY_ONE)) mainToolbarState.soundSlotActive = 0;
-        else if (IsKeyPressed(KEY_TWO)) mainToolbarState.soundSlotActive = 1;
-        else if (IsKeyPressed(KEY_THREE)) mainToolbarState.soundSlotActive = 2;
-        else if (IsKeyPressed(KEY_FOUR)) mainToolbarState.soundSlotActive = 3;
-        else if (IsKeyPressed(KEY_FIVE)) mainToolbarState.soundSlotActive = 4;
+        if (!showSaveFileDialog) {
+            // Select current sound slot
+            if (IsKeyPressed(KEY_ONE)) mainToolbarState.soundSlotActive = 0;
+            else if (IsKeyPressed(KEY_TWO)) mainToolbarState.soundSlotActive = 1;
+            else if (IsKeyPressed(KEY_THREE)) mainToolbarState.soundSlotActive = 2;
+            else if (IsKeyPressed(KEY_FOUR)) mainToolbarState.soundSlotActive = 3;
+            else if (IsKeyPressed(KEY_FIVE)) mainToolbarState.soundSlotActive = 4;
+
+            // Play current sound
+            if (IsKeyPressed(KEY_SPACE)) PlaySound(sound[mainToolbarState.soundSlotActive]);
+
+            // Toggle play on change option
+            if (IsKeyPressed(KEY_P)) playOnChange = !playOnChange;
+        }
 
         // Select visual style
         //if (IsKeyPressed(KEY_LEFT)) mainToolbarState.visualStyleActive--;
@@ -478,9 +484,6 @@ int main(int argc, char *argv[])
         // Toggle screen size (x2) mode
         if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_F)) screenSizeActive = !screenSizeActive;
 #endif
-        // Toggle play on change option
-        if (IsKeyPressed(KEY_P)) playOnChange = !playOnChange;
-
         // Toggle window: help
         if (IsKeyPressed(KEY_F1)) windowHelpState.windowActive = !windowHelpState.windowActive;
 


### PR DESCRIPTION
I was using this software on a recent game jam and had trouble saving the files. Turns out the problem was because I was typing numbers when writing the file name, pressing 1 to 5 would change the sound slot.

This commit basically disables all of the shortcuts that we press while typing (P, space and 1 to 5 numbers), this way the user can type them without triggering them.