### PR TITLE
Add support to generate audio files using the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A simple and easy-to-use fx sounds generator, based on the amazing [Dr.Petter's 
  - Configurable sample-rate, bits-per-sample and channels on export
  - Multiple GUI styles with support for custom ones (`.rgs`)
  - Command-line support for `.rfx` to `.wav` batch conversion
+ - Command-line support to generate audio files based on presets
  - Command-line audio player for `.wav`, `.ogg`, `.mp3` and `.flac`
  - **Completely portable (single-file, no-dependencies)**
  - **Free and open-source**


### PR DESCRIPTION
Motivation:
It can be useful to generate multiple different audio files using the command line (example: you want to generate multiple placeholder assets at once)
This pull request aims to add that functionality to the platform with the argument "-g <preset>" or "-generate  <preset>".

I tried to follow the same guidelines and add as little complexity as possible.

