### PR TITLE
Fixes for CMake build on desktop platforms

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -50,7 +50,9 @@ if(${BUILD_RFXGEN})
     target_link_libraries(${PROJECT_NAME} PUBLIC raylib)
 
     # Web Configurations
-    if (${PLATFORM} STREQUAL "Web")
+    if ("${PLATFORM}" STREQUAL "Web")
         set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+    else()
+        add_compile_definitions(PLATFORM_DESKTOP=)
     endif()
 endif()


### PR DESCRIPTION
Building using cmake on macOS, after `cmake -B build`, I ran into
````
CMake Error at CMakeLists.txt:53 (if):
  if given arguments:

    "STREQUAL" "Web"

  Unknown arguments specified
````
because `PLATFORM` was undefined in `CMakeLists.txt`. 

Also, at compile time, `external/tinyfiledialogs.h` was not being included, because `PLATFORM_DESKTOP` was not defined, leading to compile errors. 

This commit fixes both of these issues.